### PR TITLE
fix: handle too long title of events bug

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -48,7 +48,7 @@
     .grid-month, .grid-week { grid-template-columns: repeat(7, 1fr); }
     .grid-day { grid-template-columns: 1fr; }
 
-    .day-cell { min-height: 130px; padding: 8px; cursor: pointer; background: white; transition: background-color 0.2s; }
+    .day-cell { min-height: 130px; padding: 8px; cursor: pointer; background: white; transition: background-color 0.2s; min-width: 0; overflow: hidden;}
     .day-cell:hover { background-color: #f9fafb; }
     .day-cell.other-month { background-color: #fafafa; }
     .day-cell.other-month .date-label { color: #d1d5db; }
@@ -306,7 +306,7 @@ function renderCalendar() {
                 evDiv.innerHTML = `
                     <div class="event-dot" style="background-color: ${e.color || '#4f46e5'}"></div>
                     <span class="event-time">${e.time || ''}</span>
-                    <span style="overflow: hidden; text-overflow: ellipsis;">${e.title}</span>
+                    <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;">${e.title}</span>
                 `;
             }
             


### PR DESCRIPTION
### 問題描述
當事件標題太長時會導致此欄(column)的格子都會被跟著拉長，
多個事件標題太長會將某幾欄擠出邊界。
### 解決方式
- css 部分 `.day-cell`，加上 `min-width: 0;` 與 `overflow: hidden;` 設定最小寬度，如果超出格子則 hidden
- 非全天事件使用了 Flex ，需要額外將裡面文字加上 `white-space: nowrap; flex: 1;`

Fixes #1 