### PR TITLE
fix-no-title-event

### DIFF
--- a/routes/events_api.py
+++ b/routes/events_api.py
@@ -67,7 +67,7 @@ def create_event():
             is_all_day = bool(is_all_day_val)
 
         new_event = Event(
-            title=data.get('title'),
+            title=data.get('title') if data.get('title') else "(no title)",
             start=data.get('start'),
             end=data.get('end'),
             time=data.get('time', ''),


### PR DESCRIPTION
原本能夠建立沒標題的event，現在比照google日歷，如果title欄位為空就預設叫做(no title)