### PR TITLE
fix no time event

### DIFF
--- a/routes/events_api.py
+++ b/routes/events_api.py
@@ -114,6 +114,13 @@ def update_event(event_id):
     # 處理重複規則的更新
     if 'recurrence' in data: event.recurrence = data['recurrence']
     db.session.commit()
+
+    if not (event.is_all_day or event.time):
+        print("ERROR!")
+        return jsonify({'error': '事件必須是全天或具有時間'}), 400
+    else:
+        print("nothing happen")
+
     return jsonify(serialize_event(event)), 200
 
 @events_api.route('/<int:event_id>', methods=['DELETE'])

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -452,13 +452,20 @@ async function saveEvent(){
         recurrence: recurrenceStr 
     };
 
-    await fetch(url, { 
+    const res = await fetch(url, {
         method: method, 
         headers: {"Content-Type": "application/json"}, 
         body: JSON.stringify(data) 
     });
+
+    if (res.status === 400) {   // 後端驗證失敗
+        const err = await res.json();
+        alert(err.error);
+        return;
+    }
+
     closeModal();
-    loadEvents(); 
+    loadEvents();
 }
 
 async function deleteEvent(){


### PR DESCRIPTION
問題:
全天事件改成非全天事件時，會導致事件變成沒有時間的事件
原因:
event.all_time_event設為True時，會把event.time改成空字串，後續把event.all_time_event改回False時就會導致有沒時間(空字串)的事件產生
解決:
判斷當all_time_event為False且time為空字串時，回傳警告訊息給前端顯示，並阻止save不符合格式的event

Fixes #4