### PR TITLE
fix: handle invalid iCal format in import API

### DIFF
--- a/routes/events_api.py
+++ b/routes/events_api.py
@@ -186,7 +186,10 @@ def import_ical():
         return jsonify({'error': 'No selected file'}), 400
 
     if file:
-        cal = Calendar.from_ical(file.read())
+        try:
+            cal = Calendar.from_ical(file.read())
+        except ValueError:
+            return jsonify({'error': 'Invalid iCal format'}), 400
         for component in cal.walk():
             if component.name == "VEVENT":
                 # 避免 summary 或 description 回傳 None 被轉成 'None' 字串，提供合理預設


### PR DESCRIPTION
### 問題描述
import 有時候失敗會沒訊息

### 解決方式
在讀取檔案的部分使用 `try except`